### PR TITLE
feat: add support to provide release from options directly 

### DIFF
--- a/tasks/raygun_deployment.js
+++ b/tasks/raygun_deployment.js
@@ -69,7 +69,13 @@ module.exports = function (grunt) {
       }
     };
 
-    var release = grunt.file.readYAML(options.release);
+    var release = null;
+
+    if(typeof options.release=="string"){
+      grunt.file.readYAML(options.release);
+    } else if(typeof options.release=="object"){
+      release = options.release;
+    }
 
     if(options.useGit) {
       grunt.util.spawn({


### PR DESCRIPTION
Needing a file to provide release details is clumsy. Version number gets out of the hand when working with multiple branches / many developers.  This commit allows to send release details as a option in gruntfile. Preserves previous functionality of getting release details from file.
